### PR TITLE
fix to connect to slack and some file encoding issues

### DIFF
--- a/src/daemon/slack/receive.py
+++ b/src/daemon/slack/receive.py
@@ -52,7 +52,6 @@ proxies = System.get_request_proxies()
 wc = None
 th = None
 rtm_client = None
-post_slack_channel = None
 slack_token = None
 
 
@@ -79,7 +78,6 @@ class SlackThread(threading.Thread):
 
 
 def start_receive_slack_thread():
-    global post_slack_channel
     global slack_token
     global wc
     global th
@@ -102,7 +100,6 @@ def start_receive_slack_thread():
             SNS_SLACK_BOT_ACCOUNT,
             is_admin=False)
         slack_user.save()
-    post_slack_channel = SNSConfig.get_slack_bot_chnnel()
     wc = slack.WebClient(token=slack_token)
     rtm_client = slack.RTMClient(token=slack_token)
     th = SlackThread()
@@ -131,6 +128,7 @@ def download_stix_id(command_stix_id):
     stix_file_path = Feed.get_cached_file_path(
         command_stix_id.replace(':', '--'))
     file_name = '%s.xml' % (command_stix_id)
+    post_slack_channel = SNSConfig.get_slack_bot_chnnel()
     wc.files_upload(
         initial_comment='',
         channels=post_slack_channel,

--- a/src/daemon/slack/receive.py
+++ b/src/daemon/slack/receive.py
@@ -116,6 +116,7 @@ def restart_receive_slack_thread():
     el = rtm_client._event_loop
     th.end()
     th.join()
+    slack_token = SNSConfig.get_slack_bot_token()
     rtm_client = slack.RTMClient(
         token=slack_token,
         loop=el)

--- a/src/feeds/extractor/pdf.py
+++ b/src/feeds/extractor/pdf.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from io import StringIO
 from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.layout import LAParams
 from pdfminer.converter import TextConverter
@@ -17,7 +17,7 @@ class PDFExtractor(FileExtractor):
     # 指定の PDF ファイルを開き、indicators, cve, threat_actor の要素を返却する
     @classmethod
     def _get_element_from_target_file(cls, file_, ta_list=[], white_list=[]):
-        outfp = BytesIO()
+        outfp = StringIO()
 
         # PDF ファイルを解析する
         pdf_device = TextConverter(pdf_rsrcmgr, outfp, codec=pdf_codec, laparams=pdf_laparams)

--- a/src/feeds/feed_stix.py
+++ b/src/feeds/feed_stix.py
@@ -175,7 +175,7 @@ class FeedStix(FeedStixCommon):
             content = base64.b64encode(fp.read())
 
         # content作成
-        marking_specification_content = self._make_marking_specification_statement(MARKING_STRUCTURE_STIP_ATTACHEMENT_CONTENT_PREFIX, content)
+        marking_specification_content = self._make_marking_specification_statement(MARKING_STRUCTURE_STIP_ATTACHEMENT_CONTENT_PREFIX, content.decode('utf-8'))
         # filename作成
         marking_specification_file_name = self._make_marking_specification_statement(MARKING_STRUCTURE_STIP_ATTACHEMENT_FILENAME_PREFIX, file_.file_name)
 

--- a/src/feeds/views.py
+++ b/src/feeds/views.py
@@ -1201,8 +1201,9 @@ def save_post(request,
         slack_post = slack_post.replace('&gt;', '%amp;gt;')
 
         # Slack 投稿用の添付ファイル作成
-        from daemon.slack.receive import post_slack_channel, wc
+        from daemon.slack.receive import wc
         if wc is not None:
+            post_slack_channel = SNSConfig.get_slack_bot_chnnel()
             if temp is not None:
                 try:
                     # ファイルが添付されている場合は file uplaod をコメント付きで

--- a/src/management/views.py
+++ b/src/management/views.py
@@ -1,4 +1,3 @@
-import threading
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import render
@@ -7,8 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from ctirs.models import STIPUser, SNSConfig
 from management.forms import SNSConfigForm
 from feeds.mongo import Attck
-from django.conf import settings as django_settings
-from daemon.slack.receive import start_receive_slack_thread
+from daemon.slack.receive import restart_receive_slack_thread
 
 
 @login_required
@@ -63,7 +61,7 @@ def reboot_slack_thread(request):
     if request.user.role != 'admin':
         return HttpResponseForbidden()
     # thread 再起動
-    start_receive_slack_thread()
+    restart_receive_slack_thread()
     # その後は config 画面に遷移
     return sns_config(request)
 


### PR DESCRIPTION
Corespond to #17 .
 
I fixed to fail to connect to slack.
Python 2.7 uses slackclient library ver 1.x.
But Python 3.x uses slackclient library ver 2.x.

There are many gaps between ver1.x and 2.x.
https://github.com/slackapi/python-slackclient/wiki/Migrating-to-2.x

---

and I also fixed about file encoding issues.

---

And I found an encoding issues in RS repository.
We must merge RS and SNS at the same time.

I will open a pull request at RS repository soon.

