### PR TITLE
Supression of warning display

### DIFF
--- a/bin/post_stip.py
+++ b/bin/post_stip.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# coding: UTF-8
+import sys,traceback,argparse
+import json
+import requests
+
+##############################
+#post_stip
+#S-TIP 投稿スクリプト
+##############################
+#第1引数：URL (必須)
+#第2引数：POST 情報(必須)
+#第3引数：attachment file(任意)
+##############################
+#オプション
+# url post_info_file [attachment_file,...]
+##############################
+'''
+post_info_file例
+(例1)
+{
+    "username": "satomi",
+    "title": "test_title_from_script",
+    "post" : "line1\nline2",
+    "TLP": "GREEN",
+    "publication" : "all"
+}
+・値と項目はダブルクオーテーションでくくる
+・改行は\nで記載
+・辞書の最後の項目の後ろにカンマを入れるとエラーなので要注意
+
+(例2)
+{
+    "username": "satomi",
+    "title": "test_title_from_script",
+    "post" : "line1\nline2",
+    "TLP": "GREEN",
+    "publication" : "people",
+    "people" : "1,2,3"
+}
+・With peopleに該当する項目は "publication" : "people"
+・その場合、"people" には "uid"の数値文字列をリスト表示する(uidはauth.usersでselectしてください・・)
+
+(例3)
+{
+    "username": "satomi",
+    "title": "test_title_from_script",
+    "post" : "line1\nline2",
+    "TLP": "GREEN",
+    "publication" : "group",
+    "group" : "test_group"
+}
+・With a groupに該当する項目は "publication" : "group"
+・その場合、"group" には任意の文字列を指定可能なので注意
+
+'''
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description = 'Post S-TIP Script')
+    parser.add_argument('-u','--url',help='Post url')
+    parser.add_argument('-p','--post_info_file',help='Post setting information')
+    parser.add_argument('attachments',nargs='*',help='attachement')
+    args = parser.parse_args()
+
+    if args.url is None:
+        print 'No URL.'
+        parser.print_help()
+        sys.exit(1)
+
+    if args.post_info_file is None:
+        print 'No Post info file.'
+        parser.print_help()
+        sys.exit(1)
+
+    with open(args.post_info_file,'r') as fp:
+        payload = json.load(fp)
+
+    index = 0
+    files = {}
+    for file_path in args.attachments:
+        item_name = 'attachments_%d' % (index)
+        index += 1
+        files[item_name] = open(file_path,'rb')
+
+    r = requests.post(
+        args.url,
+        data=payload,
+        files=files,
+        verify=False)
+
+    b = json.loads(r.text)
+    if r.status_code != 200:
+        print 'Request Failed (%s, %s).' % (r.status_code,b['reason'])
+    else:
+        print 'Success!'

--- a/bin/post_stip.py
+++ b/bin/post_stip.py
@@ -1,18 +1,20 @@
 #!/usr/bin/python
 # coding: UTF-8
-import sys,traceback,argparse
+import sys
+import traceback
+import argparse
 import json
 import requests
 
 ##############################
-#post_stip
-#S-TIP 投稿スクリプト
+# post_stip
+# S-TIP 投稿スクリプト
 ##############################
-#第1引数：URL (必須)
-#第2引数：POST 情報(必須)
-#第3引数：attachment file(任意)
+# 第1引数：URL (必須)
+# 第2引数：POST 情報(必須)
+# 第3引数：attachment file(任意)
 ##############################
-#オプション
+# オプション
 # url post_info_file [attachment_file,...]
 ##############################
 '''
@@ -57,23 +59,23 @@ post_info_file例
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description = 'Post S-TIP Script')
-    parser.add_argument('-u','--url',help='Post url')
-    parser.add_argument('-p','--post_info_file',help='Post setting information')
-    parser.add_argument('attachments',nargs='*',help='attachement')
+    parser = argparse.ArgumentParser(description='Post S-TIP Script')
+    parser.add_argument('-u', '--url', help='Post url')
+    parser.add_argument('-p', '--post_info_file', help='Post setting information')
+    parser.add_argument('attachments', nargs='*', help='attachement')
     args = parser.parse_args()
 
     if args.url is None:
-        print 'No URL.'
+        print('No URL.')
         parser.print_help()
         sys.exit(1)
 
     if args.post_info_file is None:
-        print 'No Post info file.'
+        print('No Post info file.')
         parser.print_help()
         sys.exit(1)
 
-    with open(args.post_info_file,'r') as fp:
+    with open(args.post_info_file, 'r') as fp:
         payload = json.load(fp)
 
     index = 0
@@ -81,7 +83,7 @@ if __name__ == '__main__':
     for file_path in args.attachments:
         item_name = 'attachments_%d' % (index)
         index += 1
-        files[item_name] = open(file_path,'rb')
+        files[item_name] = open(file_path, 'rb')
 
     r = requests.post(
         args.url,
@@ -91,6 +93,6 @@ if __name__ == '__main__':
 
     b = json.loads(r.text)
     if r.status_code != 200:
-        print 'Request Failed (%s, %s).' % (r.status_code,b['reason'])
+        print('Request Failed (%s, %s).' % (r.status_code, b['reason']))
     else:
-        print 'Success!'
+        print('Success!')

--- a/src/api/v1/views.py
+++ b/src/api/v1/views.py
@@ -4,11 +4,12 @@ from django.http import (HttpResponseBadRequest, HttpResponse,)
 from ctirs.models import STIPUser
 from django.views.decorators.csrf import csrf_exempt
 from django.http.response import HttpResponseNotAllowed
-from feeds.views import KEY_ANONYMOUS, KEY_USERNAME, post_common
+from feeds.views import KEY_ANONYMOUS, KEY_USERNAME, post_common, confirm_indicator
 
 
 @csrf_exempt
 def post(request):
+    POST_KEY_NO_EXTRACT = 'no_extract'
     if request.method != 'POST':
         return HttpResponseNotAllowed(['POST'])
 
@@ -27,8 +28,18 @@ def post(request):
                 user = STIPUser.objects.get(username=username)
             except BaseException:
                 raise Exception('Invalid username(%s)' % (username))
+        # extract フラグ
+        extract = True
+        if POST_KEY_NO_EXTRACT in request.POST:
+            extract = False
 
-        # POSTする
+        if extract:
+            # indicators 取得
+            request.user = user
+            json_response = confirm_indicator(request)
+            j = json.loads(json_response.content)
+            # confirm_indicators から再度 post するデータを取得する
+            request.POST = get_post_common_post(request.POST.copy(), j)
         feed = post_common(request, user)
 
         dump = {
@@ -43,3 +54,59 @@ def post(request):
                 'reason': str(e)}
         data = json.dumps(dump)
         return HttpResponseBadRequest(data, content_type='application/json')
+
+
+def get_post_common_post(temp_post, j):
+    indicators_json = get_indicators(j)
+    if indicators_json is not None:
+        temp_post['indicators'] = indicators_json
+    tas_json = get_tas(j)
+    if tas_json is not None:
+        temp_post['tas'] = tas_json
+    ttps_json = get_ttps(j)
+    if ttps_json is not None:
+        temp_post['ttps'] = ttps_json
+    return temp_post
+
+
+def get_indicators(json_response):
+    temp_indicators = []
+    for title in json_response['indicators'].keys():
+        indicators = json_response['indicators'][title]
+        for indicator in indicators:
+            item = {}
+            item['type'] = indicator[0]
+            item['value'] = indicator[1]
+            item['title'] = indicator[2]
+            temp_indicators.append(item)
+    if len(temp_indicators) == 0:
+        return None
+    return json.dumps(temp_indicators)
+
+
+def get_tas(json_response):
+    temp_tas = []
+    for title in json_response['tas'].keys():
+        tas = json_response['tas'][title]
+        for ta in tas:
+            item = {}
+            item['value'] = ta[1]
+            item['title'] = ta[2]
+            temp_tas.append(item)
+    if len(temp_tas) == 0:
+        return None
+    return json.dumps(temp_tas)
+
+
+def get_ttps(json_response):
+    temp_ttps = []
+    for title in json_response['ttps'].keys():
+        ttps = json_response['ttps'][title]
+        for ttp in ttps:
+            item = {}
+            item['value'] = ttp[1]
+            item['title'] = ttp[2]
+            temp_ttps.append(item)
+    if len(temp_ttps) == 0:
+        return None
+    return json.dumps(temp_ttps)

--- a/src/feeds/extractor/common.py
+++ b/src/feeds/extractor/common.py
@@ -19,7 +19,7 @@ from feeds.mongo import Cve
 from ctirs.models import SNSConfig
 
 # regular expression
-ipv4_reg_expression = r'.*?((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[[]{0,1}\.[\]]{0,1}){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)).*?$'
+ipv4_reg_expression = r'.*?((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\[]{0,1}\.[\]]{0,1}){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)).*?$'
 ipv4_reg = re.compile(ipv4_reg_expression)
 url_reg_expression = r'.*?(https?|ftp)\[?(:)\]?(\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+).*?$'
 url_reg = re.compile(url_reg_expression)
@@ -31,7 +31,7 @@ sha256_expression = '.*?(([0-9]|[a-f]|[A-F]){64}).*?$'
 sha256_reg = re.compile(sha256_expression)
 sha512_expression = '.*?(([0-9]|[a-f]|[A-F]){128}).*?$'
 sha512_reg = re.compile(sha512_expression)
-domain_expression = r'.*?([A-Za-z0-9][A-Za-z0-9_-]*(\.[A-Za-z][A-Za-z0-9_-]*)*([[]{0,1}\.[\]]{0,1}[A-Za-z][A-Za-z][A-Za-z]*)).*?'
+domain_expression = r'.*?([A-Za-z0-9][A-Za-z0-9_-]*(\.[A-Za-z][A-Za-z0-9_-]*)*([\[]{0,1}\.[\]]{0,1}[A-Za-z][A-Za-z][A-Za-z]*)).*?'
 domain_reg = re.compile(domain_expression)
 cve_expression = '.*(CVE-([0-9]){4}-([0-9]){1,5}).*$'
 cve_reg = re.compile(cve_expression)
@@ -55,7 +55,7 @@ JSON_OBJECT_TYPE_EMAIL_ADDRESS = 'email_address'
 
 
 class BaseExtractor(object):
-    word_extract_expression = r'([[\]\-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)'
+    word_extract_expression = r'([\[\]\-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)'
     word_extract_reg = re.compile(word_extract_expression)
     CVE_TYPE_STR = 'cve'
     TA_TYPE_STR = 'threat_actor'
@@ -178,12 +178,12 @@ class FileExtractor(BaseExtractor):
     # Extract 対象ファイルを返却
     @classmethod
     def _get_target_files(cls, files):
-        l = []
+        ret_ = []
         if files is not None:
             for file_ in files:
                 if cls._is_target_file(file_.file_name):
-                    l.append(file_)
-        return l
+                    ret_.append(file_)
+        return ret_
 
     # Extract 対象 ファイルであるかの判定ロジック
     @classmethod

--- a/src/feeds/views.py
+++ b/src/feeds/views.py
@@ -384,7 +384,6 @@ def is_stix2_post(request):
 
 
 @login_required
-@ajax_required
 # 添付されたファイルに indicators が含まれているかを確認する
 def confirm_indicator(request):
     # 添付ファイルごとに AttachFile を作成し list に格納　


### PR DESCRIPTION
Currently, nested regular expression (like `'[[]'`) is valid.
But, in python3, this expression is not deprecated and display future warnings before launching.
So I modified these expression like ` '[\[\]'`.
And I modified some deprecated variables ( l -> ret_).

