### PR TITLE
Fixed to apply CTI Element Extractor via Slack.

### DIFF
--- a/src/api/v1/views.py
+++ b/src/api/v1/views.py
@@ -36,10 +36,8 @@ def post(request):
         if extract:
             # indicators 取得
             request.user = user
-            json_response = confirm_indicator(request)
-            j = json.loads(json_response.content)
             # confirm_indicators から再度 post するデータを取得する
-            request.POST = get_post_common_post(request.POST.copy(), j)
+            request = get_request_via_confirm_indicator(request)
         feed = post_common(request, user)
 
         dump = {
@@ -54,6 +52,15 @@ def post(request):
                 'reason': str(e)}
         data = json.dumps(dump)
         return HttpResponseBadRequest(data, content_type='application/json')
+
+
+# RestAPI, Slack 共通
+def get_request_via_confirm_indicator(request):
+    json_response = confirm_indicator(request)
+    j = json.loads(json_response.content)
+    # confirm_indicators から再度 post するデータを取得する
+    request.POST = get_post_common_post(request.POST.copy(), j)
+    return request
 
 
 def get_post_common_post(temp_post, j):

--- a/src/daemon/slack/receive.py
+++ b/src/daemon/slack/receive.py
@@ -13,6 +13,7 @@ from django.http.request import HttpRequest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from ctirs.models import System, STIPUser, SNSConfig, AttachFile, Feed
 from stip.common.const import TLP_CHOICES, SNS_SLACK_BOT_ACCOUNT
+from api.v1.views import get_request_via_confirm_indicator
 from feeds.views import get_merged_conf_list, post_common
 from feeds.extractor.base import Extractor
 from feeds.views import KEY_TLP as STIP_PARAMS_INDEX_TLP
@@ -270,6 +271,9 @@ def post_stip_from_slack(receive_data, slack_bot_channel_name, slack_user):
         request.POST = stip_params
         request.FILES = files_for_stip_post
         request.META['SERVER_NAME'] = 'localhost'
+        request.user = slack_user
+        request = get_request_via_confirm_indicator(request)
+        # ここから rest api 経由としたい
         post_common(request, slack_user)
     except Exception as e:
         import traceback

--- a/src/daemon/slack/receive.py
+++ b/src/daemon/slack/receive.py
@@ -13,7 +13,6 @@ from django.http.request import HttpRequest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from ctirs.models import System, STIPUser, SNSConfig, AttachFile, Feed
 from stip.common.const import TLP_CHOICES, SNS_SLACK_BOT_ACCOUNT
-from api.v1.views import get_request_via_confirm_indicator
 from feeds.views import get_merged_conf_list, post_common
 from feeds.extractor.base import Extractor
 from feeds.views import KEY_TLP as STIP_PARAMS_INDEX_TLP
@@ -272,8 +271,6 @@ def post_stip_from_slack(receive_data, slack_bot_channel_name, slack_user):
         request.FILES = files_for_stip_post
         request.META['SERVER_NAME'] = 'localhost'
         request.user = slack_user
-        request = get_request_via_confirm_indicator(request)
-        # ここから rest api 経由としたい
         post_common(request, slack_user)
     except Exception as e:
         import traceback


### PR DESCRIPTION
Like a REST API post, S-TIP SNS extract CTI Element from post via Slack.

<Notice>
If  Slack account does not check Element Extractor option, this function is disabled.
