### PR TITLE
Fix to specify the timezone in the .env file.

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -33,6 +33,11 @@ try:
 except UndefinedValueError:
     mysql_port = '3306'
 
+try:
+    TIME_ZONE = config('TIME_ZONE')
+except UndefinedValueError:
+    TIME_ZONE = 'UTC'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',


### PR DESCRIPTION
Please add `TIME_ZONE=Asia/Tokyo` in your .env file.
If no 'TIME_ZONE' value in .env file, S-TIP can use the `UTC` timezone.
