### PR TITLE
Refactoring for extract_tags and create_link_tags.

### DIFF
--- a/src/feeds/views.py
+++ b/src/feeds/views.py
@@ -93,8 +93,8 @@ def feeds(request):
     else:
         from_feed = None
     for i in range(len(feeds)):
-        feed_words, tag_indexes = extract_tags(feeds[i].post)
-        feeds[i].post = create_link_tags(feed_words, tag_indexes)
+        tags = extract_tags(feeds[i].post)
+        feeds[i].post = create_tag_links(tags, feeds[i].post)
     r = render(request, 'feeds/feeds.html', {
         'feeds': feeds,
         'jira': imported_jira,
@@ -151,8 +151,8 @@ def load(request):
     html = ''
     csrf_token = (csrf(request)['csrf_token'])
     for feed in feeds:
-        feed_words, tag_indexes = extract_tags(feed.post)
-        feed.post = create_link_tags(feed_words, tag_indexes)
+        tags = extract_tags(feed.post)
+        feed.post = create_tag_links(tags, feed.post)
         html = '{0}{1}'.format(
             html,
             render_to_string(
@@ -175,8 +175,8 @@ def _html_feeds(last_feed_datetime, user, csrf_token, feed_source='all'):
     feeds = Feed.get_feeds_after(last_feed_datetime=last_feed_datetime, api_user=user, user_id=user_id)
     html = ''
     for feed in feeds:
-        feed_words, tag_indexes = extract_tags(feed.post)
-        feed.post = create_link_tags(feed_words, tag_indexes)
+        tags = extract_tags(feed.post)
+        feed.post = create_tag_links(tags, feed.post)
         html = '{0}{1}'.format(
             html,
             render_to_string(
@@ -1431,8 +1431,7 @@ def save_post(request,
         x_stip_sns_attachment_refs = None
 
     # hashtag
-    feed_words, tag_indexes = extract_tags(post)
-    tags = [feed_words[i] for i in tag_indexes]
+    tags = extract_tags(post)
     
     bundle = get_post_stix2_bundle(
         json_indicators,
@@ -1633,33 +1632,32 @@ def check_match_query(request, user):
     return True
 
 
-def extract_tags(feed):
-    tag_indexes = []
+def extract_tags(post):
+    tags = []
     delimiter_string = string.punctuation.translate(str.maketrans({'#':'', '_':''})) + string.whitespace
-    feed_words = re.split('([' + delimiter_string + '])', feed)
+    feed_words = re.split('([' + delimiter_string + '])', post)
     feed_words = [i for i in feed_words if i != '']
-    for i in range(len(feed_words)):
-        word = feed_words[i]
+    for word in feed_words:
         if word[0] != '#':
             continue
         if len(word) == 1:
             continue
         if len(word) > const.MAX_HASHTAG_LENGTH:
             continue
-        if re.match(sharp_underbar_reg, word) != None:
+        if re.match(sharp_underbar_reg, word):
             continue
         if '#' in word[1:]:
             continue
-        if re.match(sharp_underbar_numeric_reg, word) != None:
+        if re.match(sharp_underbar_numeric_reg, word):
             continue
-        tag_indexes.append(i)
-    return feed_words, tag_indexes
+        tags.append(word)
+    return list(set(tags))
 
 
-def create_link_tags(feed_words, tag_indexes):
-    for i in tag_indexes:
-        tag_word = feed_words[i]
-        encode_tag_word = urllib.parse.quote(tag_word)
-        feed_words[i] = '<a href=/search/?q=' + encode_tag_word + '>' + tag_word + '</a>'
-    return ''.join(feed_words)
-
+def create_tag_links(tags, post):
+    for tag in tags:
+        if tag in post:
+            encode_tag_word = urllib.parse.quote(tag)
+            link_str = '<a href=/search/?q=' + encode_tag_word + '>' + tag + '</a>'
+            post = post.replace(tag, link_str)
+    return post

--- a/src/search/views.py
+++ b/src/search/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.shortcuts import redirect, render
 from ctirs.models import Group, Feed, STIPUser as User
-from feeds.views import extract_tags, create_tag_links
+from feeds.views import extract_tags
 
 try:
     from jira import JIRA
@@ -38,13 +38,11 @@ def search(request):
         query_string = None
         feeds = []
         from_feed = None
-    # �ŏI�X�V����
     last_reload = str(datetime.datetime.now())
-    # anonymous�ȊO�̑S���[�U��ԋp����
     users_list = User.objects.filter(is_active=True).exclude(username='anonymous').order_by('username')
     for i in range(len(feeds)):
-        tags = extract_tags(feeds[i].post)
-        feeds[i].post = create_tag_links(tags, feeds[i].post)
+        _, post = extract_tags(feeds[i].post)
+        feeds[i].post = post
     r = render(request, 'search/search.html', {
         'feeds': feeds,
         'jira': imported_jira,

--- a/src/search/views.py
+++ b/src/search/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.shortcuts import redirect, render
 from ctirs.models import Group, Feed, STIPUser as User
-from feeds.views import extract_tags, create_link_tags
+from feeds.views import extract_tags, create_tag_links
 
 try:
     from jira import JIRA
@@ -38,14 +38,14 @@ def search(request):
         query_string = None
         feeds = []
         from_feed = None
-    # ÅIXVŠÔ
+    # ï¿½ÅIï¿½Xï¿½Vï¿½ï¿½ï¿½ï¿½
     last_reload = str(datetime.datetime.now())
-    # anonymousˆÈŠO‚Ì‘Sƒ†[ƒU‚ğ•Ô‹p‚·‚é
+    # anonymousï¿½ÈŠOï¿½Ì‘Sï¿½ï¿½ï¿½[ï¿½Uï¿½ï¿½Ô‹pï¿½ï¿½ï¿½ï¿½
     users_list = User.objects.filter(is_active=True).exclude(username='anonymous').order_by('username')
     for i in range(len(feeds)):
-        feed_words, tag_indexes = extract_tags(feeds[i].post)
-        feeds[i].post = create_link_tags(feed_words, tag_indexes)
-    r = render(request, 'search/search.html',{
+        tags = extract_tags(feeds[i].post)
+        feeds[i].post = create_tag_links(tags, feeds[i].post)
+    r = render(request, 'search/search.html', {
         'feeds': feeds,
         'jira': imported_jira,
         'from_feed': from_feed,


### PR DESCRIPTION
For #97 

We should refactor below.

- Rename `create_link_tags` to `create_tag_links` (Because this function does not create tags)
- `extra_tags` returns a list of tags only (Because the only information that he caller really needs is the tag list)
- Rename `feed` arg value in `extract_tags` to `post` (In the `views.py`, `feed` means an instance of feed. However, the arg value is used for content of post in `extra_tags`)
- Change comparison of `re.match` (Because pep8 warns `is not None` )
- `extra_tags` returns a tags list without duplication
- Change arg values of `create_tag_links` 
- Removed the last two newlines in `feeds/views.py` (Because pep8 warns it)

---

以下の修正を行います。挙動の変更はありません (リファクタリングです)

-  `create_link_tags` の関数名を `create_tag_links` に変更 (この関数では tags を作成するのではなく、link を作成するので)
- `extra_tags` は tag list だけを返却するように変更 (呼び出し元が本当に必要な情報は post に含まれる tag のリストだから)
- `extract_tags` の引数の `feed` の変数名を  `post` に変更 (`views.py` ないでは `feed` 変数は `Feed` クラスのインスタンス名を表していることが多い。この関数では post の内容,つまり、 str 型が渡るので)
- `re.match` の判定文を変更 ( `is not None` 表記が pep8 check にひっかかるので)
- `extra_tags` の返却する Tags リストから重複を省きました
- `create_tag_links` の引数の変数名を変更しました
- `feeds/views.py` の末尾の余分な空白を削除 (pep8 が警告するので)
