### PR TITLE
Remove ga.js

### DIFF
--- a/src/static/js/ga.js
+++ b/src/static/js/ga.js
@@ -1,7 +1,0 @@
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-42049022-5', 'vitorfs.com');
-  ga('send', 'pageview');


### PR DESCRIPTION
About the #125 issue.
`ga.js` is no longer used.
We should remove it.
