### PR TITLE
Ignore an Ajax error on MacOS Safari

### DIFF
--- a/src/core/static/js/stip_ajax.js
+++ b/src/core/static/js/stip_ajax.js
@@ -4,6 +4,17 @@ const suggest_limit = 5
 const suggest_min_length = 2
 
 
+function is_safari(){
+  var userAgent = window.navigator.userAgent.toLowerCase()
+  if (userAgent.indexOf('safari') == -1) {
+    return false
+  }
+  if (userAgent.indexOf('chrome') != -1) {
+    return false
+  }
+  return true
+}
+
 $(document)
   .ajaxError(function (e, xhr, opts, error) {
     console.log('AjaxError: ' + error);
@@ -11,7 +22,9 @@ $(document)
       alert('Session Timeout!!. Back to the Login Page.')
       window.location.href = '/login'
     } else {
-      alert(error);
+      if(!is_safari()){
+        alert(error);
+      }
     }
   });
 


### PR DESCRIPTION
When a user with MacOS Safari tries to download some files (i.e. STIX, csv), sometimes an error occur.
I have investigated this reason and understand that if a user submit form during an ajax communication, this error occurs.
 I cannot reach how to fix it.
However, even if an error occurs, the user can download the file with displaying the dialog.
So, as a temporary measure, I decided to ignore the error in Mac Safari.
Let's deal with it when we have time.

---

MacOS Safari ユーザーが SNS でファイルをダウンロードするとエラーが発生することがあります。
調査したところ、5 秒に一度、投稿情報を更新しに ajax 通信をしている最中 (その ajax 通信を中断する形で) submit() を行うとエラーが発生するようです。
ただ、対処方法が不明です。
しかしながら、エラーダイアログが表示されるだけど、ファイルはダウンロードされるし、引き続き投稿情報更新は実施されます。
そこで、一時対処として、Mac Safari の場合に、そのエラーを無視することにしました。
本格的対処は時間が取れてから対応しましょう。
