### PR TITLE
Issue about JavaScript translation.

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware'
 ]
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 

--- a/src/urls.py
+++ b/src/urls.py
@@ -34,8 +34,8 @@ urlpatterns = [
     url(r'^notifications/last/$', activities_views.last_notifications, name='last_notifications'),
     url(r'^notifications/check/$', activities_views.check_notifications, name='check_notifications'),
     url(r'^search/$', search_views.search, name='search'),
-    url(r'^(?P<username>[^/]+)/$', core_views.profile, name='profile'),
-    url(r'^jsi18n/$', JavaScriptCatalog.as_view())
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view()),
+    url(r'^(?P<username>[^/]+)/$', core_views.profile, name='profile')
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Issue about #146 .

In pull request #143, I deleted a middlewarewhich uses to translate  in `settings.py` .

```
    'django.middleware.locale.LocaleMiddleware',
```

That's wrong. This middleware is needed for translation.


