### PR TITLE
Fix installation error

### DIFF
--- a/src/feeds/migrations/0013_feed_package_id.py
+++ b/src/feeds/migrations/0013_feed_package_id.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feed',
             name='package_id',
-            field=models.TextField(default='', max_length=128, null=True),
+            field=models.TextField(max_length=128, null=True),
         ),
     ]


### PR DESCRIPTION
Issue about #151 .

---

An installation error occurs under the latest django library.
This was due to an incompatibility in the migration file by the django library.
I installed it from the beginning and checked it to boot.

