### PR TITLE
Support the latest Slack Libary.

### DIFF
--- a/src/feeds/views.py
+++ b/src/feeds/views.py
@@ -358,7 +358,12 @@ def post_common(request, user):
     if KEY_TLP not in request.POST:
         raise Exception('No TLP.')
     feed.tlp = request.POST[KEY_TLP]
-    feed.confidence = request.POST[KEY_CONFIDENCE]
+
+    if KEY_CONFIDENCE in request.POST:
+        feed.confidence = request.POST[KEY_CONFIDENCE]
+    else:
+        feed.confidence = '100'
+
 
     # multi language 投稿か？
     stix2_titles = []

--- a/src/management/views.py
+++ b/src/management/views.py
@@ -48,6 +48,8 @@ def reboot_slack_thread(request):
         return HttpResponseForbidden('You have no permission.')
     # thread 再起動
     slack_web_client, slack_rtm_client, th = restart_receive_slack_thread()
+    if th is None:
+        return sns_config(request)
     StipSnsBoot.slack_web_client = slack_web_client
     StipSnsBoot.slack_rtm_client = slack_rtm_client
     StipSnsBoot.th = th


### PR DESCRIPTION
When I was testing `S-TIP` on Ubuntu 22.04, I realized that the slack library (`slackclient`) which S-TIP uses will be deprecated by the end of September.
We should support the latest Slack library (`slack_sdk`).
I also fixed some issues about the slack.
